### PR TITLE
The time the button is held is now reported with a button press

### DIFF
--- a/command.h
+++ b/command.h
@@ -29,7 +29,7 @@ class Command {
 public:
   int cellNumber;
 
-  byte command[4]; //TODO: it was only made public for testing
+  byte command[4];
 
   SerialPort rxPort; //TODO: it was only made public for testing
 

--- a/firmware.ino
+++ b/firmware.ino
@@ -40,11 +40,15 @@ void loop() {
     processNewCommand(softwareCommand);
   }
   else if (digitalRead(BUTTON_PIN) == LOW) {
+    unsigned long startTime = millis();
     delay(BUTTON_DEBOUNCE_TIME);
     if (digitalRead(BUTTON_PIN) == LOW) {
-      Command buttonPressCmd = Command(0, BUTTON_PRESS, thisCell, HARDWARE);
-      buttonPressCmd.send();
       while (digitalRead(BUTTON_PIN) == LOW) delay(10);
+      int numberOfTicks = (millis() - startTime) * 0.06;
+      Command buttonPressCmd = Command(0, BUTTON_PRESS, 0, HARDWARE);
+      buttonPressCmd.command[2] = thisCell;
+      buttonPressCmd.command[3] = numberOfTicks % 256;
+      buttonPressCmd.send();
     }
   }
   delay(10);

--- a/firmware.ino
+++ b/firmware.ino
@@ -45,6 +45,7 @@ void loop() {
     if (digitalRead(BUTTON_PIN) == LOW) {
       while (digitalRead(BUTTON_PIN) == LOW) delay(10);
       int numberOfTicks = (millis() - startTime) * 0.06;
+      if (numberOfTicks > 255) numberOfTicks = 255; //prevent overflow
       Command buttonPressCmd = Command(0, BUTTON_PRESS, 0, HARDWARE);
       buttonPressCmd.command[2] = thisCell;
       buttonPressCmd.command[3] = numberOfTicks % 256;


### PR DESCRIPTION
Change the behaviour of the BUTTON_PRESS command in two ways:

1. The command is sent when the button is RELEASED, rather than pressed.
2. The time that the button is held down is sent in the fourth
   command byte, with the cell number being contained in the
   third byte.

The time the button was held down for is sent in 60ths of a second.
This is because the value can only range from 0 to 255 in integers,
so sending seconds would be too small whilst millisecond would be
too large. 60ths of seconds allow for a maximum button press time of
4.25 seconds, which seems reasonable.